### PR TITLE
Add partitioned storage to conveyor loader

### DIFF
--- a/ImprovedFilteredStorage/Patches.cs
+++ b/ImprovedFilteredStorage/Patches.cs
@@ -133,5 +133,14 @@ namespace ImprovedFilteredStorage
                 go.AddOrGet<ImprovedTreeFilterable>();
             }
         }
+
+        [HarmonyPatch(typeof(SolidConduitInboxConfig), "DoPostConfigureComplete")]
+        public static class Patch_SolidConduitInboxConfig_DoPostConfigureComplete
+        {
+            internal static void Postfix(GameObject go)
+            {
+                go.AddOrGet<ImprovedTreeFilterable>();
+            }
+        }
     }
 }


### PR DESCRIPTION
Does what it says on the tin, adds partitioned storage to conveyor loaders. Kinda nice if you want to create 1kg loaders for sending food packages via rail.