### PR TITLE
use a shorter button label to prevent it from being 2 lines

### DIFF
--- a/ImprovedFilteredStorage/Strings.cs
+++ b/ImprovedFilteredStorage/Strings.cs
@@ -8,8 +8,8 @@ namespace ImprovedFilteredStorage
 {
     public static class Strings
     {
-        public static LocString BUTTON_ENABLE = "Enable Partitioned Storage";
-        public static LocString BUTTON_DISABLE = "Disable Partitioned Storage";
+        public static LocString BUTTON_ENABLE = "Enable Partitions";
+        public static LocString BUTTON_DISABLE = "Disable Partitions";
 
         public static LocString NOCONTENT = "Nothing selected";
     }

--- a/ImprovedFilteredStorage/desc.txt
+++ b/ImprovedFilteredStorage/desc.txt
@@ -1,5 +1,5 @@
 Simple mod that allows you to put exact amounts into storage (my use-case was the cargo module), like 100kg of coal + 1000kg of copper ore, etc.
-To use: click the new "Enable Partitioned Storage" Button on the building, select what types of stuff you want to store, then enter the amounts. Can be removed/added to existing saves, though if you delete the mod you may have to re-check previously enabled building and reset the the "store only up to x kg" slider.
+To use: click the new "Enable Partitions" Button on the building, select what types of stuff you want to store, then enter the amounts. Can be removed/added to existing saves, though if you delete the mod you may have to re-check previously enabled building and reset the the "store only up to x kg" slider.
 
 Works right now for (smart) storage bins, Orbital Cargo Modules, and Ration Box/Refrigerators.
 


### PR DESCRIPTION
The existing label is too long to fit into one line and results in a button with two lines, which looks broken. If you don't like this specific change, please consider using some other shorter label.
